### PR TITLE
Fix tiny warning in multicluster observability

### DIFF
--- a/03.Observability/exercise/multiclusterobservability.yaml
+++ b/03.Observability/exercise/multiclusterobservability.yaml
@@ -1,4 +1,4 @@
-apiVersion: observability.open-cluster-management.io/v1beta1
+apiVersion: observability.open-cluster-management.io/v1beta2
 kind: MultiClusterObservability
 metadata:
   name: observability #Your customized name of MulticlusterObservability CR
@@ -12,7 +12,7 @@ spec:
   retentionResolution1h: 30d # How long to retain samples of 1 hour in bucket
   retentionResolution5m: 14d
   retentionResolutionRaw: 5d
-  storageConfigObject: # Specifies the storage to be used by Observability
+  storageConfig: # Specifies the storage to be used by Observability
     metricObjectStorage:
       name: thanos-object-storage
       key: thanos.yaml


### PR DESCRIPTION
Got this warning while going through the workshop:

  $ oc apply -f https://raw.githubusercontent.com/michaelkotelnikov/rhacm-workshop/master/03.Observability/exercise/multiclusterobservability.yaml -n open-cluster-management-ob servability
  W0325 21:03:50.356740  117051 warnings.go:70] observability.open-cluster-management.io/v1beta1 MultiClusterObservability is deprecated in v2.3+, unavailable in v2.6+; use observability.open-cluster-management.io/v1beta2 MultiClusterObservability
  W0325 21:03:50.501598  117051 warnings.go:70] observability.open-cluster-management.io/v1beta1 MultiClusterObservability is deprecated in v2.3+, unavailable in v2.6+; use observability.open-cluster-management.io/v1beta2 MultiClusterObservability
  multiclusterobservability.observability.open-cluster-management.io/observability created

Moving this yaml to observability.open-cluster-management.io/v1beta2
since it is deprecated in 2.3+
