### PR TITLE
Updated api version of ManagedClusterSet

### DIFF
--- a/04.Application-Lifecycle/README.md
+++ b/04.Application-Lifecycle/README.md
@@ -306,7 +306,7 @@ Create the next ManagedClusterSet resource. The ManagedClusterSet resource will 
 ```
 <hub> $ cat >> managedclusterset.yaml << EOF
 ---
-apiVersion: cluster.open-cluster-management.io/v1alpha1
+apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: ManagedClusterSet
 metadata:
   name: all-clusters


### PR DESCRIPTION
Updated api version of ManagedClusterSet to v1beta1. Old api v1alpha1 is deprecated